### PR TITLE
Update Rms type to use new Fixed ring buffer type rather than VecDeque

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/MindBuffer/envelope_detector.git"
 homepage = "https://github.com/MindBuffer/envelope_detector"
 
 [dependencies]
-sample = "0.6.0"
+sample = "0.8.0"
 
 [dev-dependencies]
 portaudio = "0.6.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envelope_detector"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     "mitchmindtree <mitchell.nordine@gmail.com>",
     "JoshuaBatty"

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -19,19 +19,19 @@ fn run() -> Result<(), pa::Error> {
     const ATTACK_MS: f64 = 1.0;
     const RELEASE_MS: f64 = 1.0;
 
-    let window = time::Ms(WINDOW_SIZE_MS).samples(SAMPLE_HZ) as usize;
+    let window_size = time::Ms(WINDOW_SIZE_MS).samples(SAMPLE_HZ) as usize;
+    let window = vec![[0.0; CHANNELS]; window_size];
+    let ring_buffer = sample::ring_buffer::Fixed::from(window);
     let attack = time::Ms(ATTACK_MS).samples(SAMPLE_HZ) as f32;
     let release = time::Ms(RELEASE_MS).samples(SAMPLE_HZ) as f32;
-    let mut envelope_detector = EnvelopeDetector::rms(window, attack, release);
+    let mut envelope_detector = EnvelopeDetector::rms(ring_buffer, attack, release);
 
     // Callback used to construct the duplex sound stream.
     let callback = move |pa::InputStreamCallbackArgs { buffer, .. }| {
 
-        let window_frames = time::Ms(WINDOW_SIZE_MS).samples(SAMPLE_HZ) as usize;
         let attack = time::Ms(ATTACK_MS).samples(SAMPLE_HZ) as f32;
         let release = time::Ms(RELEASE_MS).samples(SAMPLE_HZ) as f32;
 
-        envelope_detector.set_window_frames(window_frames);
         envelope_detector.set_attack_frames(attack);
         envelope_detector.set_release_frames(release);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ extern crate sample;
 pub use mode::Mode;
 pub use peak::Peak;
 pub use rms::Rms;
-pub use sample::{Frame, Sample};
+pub use sample::{ring_buffer, Frame, Sample};
 
 pub mod mode;
 pub mod peak;
@@ -40,7 +40,7 @@ pub struct EnvelopeDetector<F, M>
 }
 
 /// An `EnvelopeDetector` that tracks the signal envelope using RMS.
-pub type RmsEnvelopeDetector<F> = EnvelopeDetector<F, Rms<F>>;
+pub type RmsEnvelopeDetector<F, S> = EnvelopeDetector<F, Rms<F, S>>;
 /// An `EnvelopeDetector` that tracks the full wave `Peak` envelope of a signal.
 pub type PeakEnvelopeDetector<F> = EnvelopeDetector<F, Peak<peak::FullWave>>;
 
@@ -50,21 +50,15 @@ fn calc_gain(n_frames: f32) -> f32 {
 }
 
 
-impl<F> EnvelopeDetector<F, Rms<F>>
+impl<F, S> EnvelopeDetector<F, Rms<F, S>>
     where F: Frame,
+          S: ring_buffer::Slice<Element=F::Float> + ring_buffer::SliceMut,
 {
-
     /// Construct a new **Rms** **EnvelopeDetector**.
-    pub fn rms(rms_window_frames: usize, attack_frames: f32, release_frames: f32) -> Self {
-        let rms = Rms::new(rms_window_frames);
+    pub fn rms(buffer: ring_buffer::Fixed<S>, attack_frames: f32, release_frames: f32) -> Self {
+        let rms = Rms::new(buffer);
         Self::new(rms, attack_frames, release_frames)
     }
-
-    /// Set the duration of the **Rms** window in frames.
-    pub fn set_window_frames(&mut self, n_window_frames: usize) {
-        self.mode.set_window_frames(n_window_frames);
-    }
-
 }
 
 impl<F> EnvelopeDetector<F, Peak<peak::FullWave>>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 #![deny(missing_copy_implementations)]
 #![deny(missing_docs)]
 
-extern crate sample;
+pub extern crate sample;
 
 pub use mode::Mode;
 pub use peak::Peak;

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -5,7 +5,7 @@
 
 use peak::{self, Peak};
 use rms::Rms;
-use sample::{Frame, Sample};
+use sample::{ring_buffer, Frame, Sample};
 
 
 /// The mode used to detect the envelope of a signal.
@@ -25,8 +25,9 @@ impl<F, R> Mode<F> for Peak<R>
     }
 }
 
-impl<F> Mode<F> for Rms<F>
+impl<F, S> Mode<F> for Rms<F, S>
     where F: Frame,
+          S: ring_buffer::Slice<Element=F::Float> + ring_buffer::SliceMut,
 {
     fn next_frame(&mut self, frame: F) -> F {
         self.next(frame).map(|s| s.to_sample::<F::Sample>())


### PR DESCRIPTION
This should improve the efficiency of Rms in many cases.

See RustAudio/sample#75 and RustAudio/sample#77 for related discussion
around the new `Fixed` ring buffer type.

Updates to use sample crate version 0.8.